### PR TITLE
[T-869d3tq4m] Permettre de modifier le nom prénom par l'utilisateur

### DIFF
--- a/controler/pages/settings.php
+++ b/controler/pages/settings.php
@@ -7,6 +7,9 @@ requireLogin();
 $title = "Settings";
 $page_name = "Settings";
 
+$username = $_SESSION['username'] ?? '';
+
+
 require $_SERVER['DOCUMENT_ROOT'] . '/public/view/helpers/header.php';
 require $_SERVER['DOCUMENT_ROOT'] . '/public/view/settings.php';
 require $_SERVER['DOCUMENT_ROOT'] . '/public/view/helpers/footer.php';

--- a/controler/updating_elements/settings.php
+++ b/controler/updating_elements/settings.php
@@ -1,0 +1,22 @@
+<?php
+
+require_once $_SERVER['DOCUMENT_ROOT'] . '/controler/helpers/auth.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . '/database/tables/user.php';
+
+requireLoginApi();
+
+$data = json_decode(file_get_contents('php://input'), true);
+$username = trim($data['username'] ?? '');
+
+if (empty($username)) {
+    echo json_encode(['success' => false, 'message' => 'Nom invalide.']);
+    exit;
+}
+
+$user = new User($_SESSION['email']);
+$user->setUsername($username);
+$user->update();
+
+$_SESSION['username'] = $username;
+
+echo json_encode(['success' => true]);

--- a/index.php
+++ b/index.php
@@ -33,6 +33,7 @@ $routes = [
     // API - UPDATE
     '/api/update/account' => 'controler/updating_elements/account.php',
     '/api/update/event'   => 'controler/updating_elements/event.php',
+    '/api/update/settings' => 'controler/updating_elements/settings.php',
 
     // API - DELETE
     '/api/delete/account'   => 'controler/deleting_elements/account.php',

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -1,3 +1,28 @@
 onload = () => {
     document.getElementById("loading-gif").style.display = "none";
 }
+
+function saveSettings() {
+    const username = document.getElementById("input-username").value.trim();
+
+    if (!username) {
+        new_popup("Le nom d'utilisateur ne peut pas être vide.", "warn");
+        return;
+    }
+
+    fetch("/api/update/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: username })
+    })
+    .then(res => res.json())
+    .then(data => {
+        if (data.success) {
+            new_popup("Nom sauvegardé avec succès.", "success");
+            document.getElementById("username").textContent = username;
+        } else {
+            new_popup("Erreur : " + data.message, "error");
+        }
+    })
+    .catch(() => new_popup("Erreur réseau.", "error"));
+}

--- a/public/view/settings.php
+++ b/public/view/settings.php
@@ -5,13 +5,8 @@
         <h2>Paramètres</h2>
 
         <div class="settings-group">
-            <label for="opt-nom">Nom</label>
-            <input type="text" id="opt-nom" placeholder="Votre nom">
-        </div>
-
-        <div class="settings-group">
-            <label for="opt-prenom">Prénom</label>
-            <input type="text" id="opt-prenom" placeholder="Votre prénom">
+            <label for="username">Nom d'utilisateur</label>
+            <input type="text" id="input-username" value="<?= htmlspecialchars($username) ?>" placeholder="Entrez votre nom d'utilisateur">
         </div>
 
         <div class="settings-group">
@@ -24,7 +19,7 @@
             <input type="checkbox" id="opt-theme">
         </div>
 
-        <button class="valide_button" onclick="">Sauvegarder</button>
+        <button class="valide_button" onclick="saveSettings()">Sauvegarder</button>
     </div>
 </section>
 


### PR DESCRIPTION
L'utilisateur peut modifier son nom d'utilisateur lui même depuis la page des paramètres. Les requêtes api passe bien par le système de routing.
Pas de modification de la base de données nécessaire.
Le nom de l'utilisateur en haut à droite s'actualise automatiquement sans rafraichissement de la page.

Popup de confirmation pour confirmer l'utilisateur de la réussite. (Popup erreur au contraire)

<img width="1919" height="960" alt="image" src="https://github.com/user-attachments/assets/1bce3013-40ad-4c0a-b7c7-8740b8531a9a" />
<img width="1915" height="958" alt="image" src="https://github.com/user-attachments/assets/2b8a3af8-a124-4316-abf5-6fe54c8cbbb2" />

