### PR TITLE
[T-869d3u09b] Modification du popup de confirmation

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -41,7 +41,7 @@ onload = () => {
 
                         <div class="col col-4" data-label="Actions">
                             <img src="/assets/images/edit.png" alt="edit" class="card-button" onclick="edit_element(${account.id_account},this)">
-                            <img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="delete_element(${account.id_account})">
+                            <img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="confirm_popup_delete_element(${account.id_account})">
                         </div>
                     </tr>`;
             });
@@ -242,23 +242,35 @@ function confirm_edit_element(label, sold, type, id) {
     }
 }
 
+function confirm_popup_delete_element(id) {
+    confirm_popup(
+        "Suppression d'un compte",
+        "Êtes-vous sûr de vouloir supprimer ce compte ? Cette action est irréversible.",
+        () => { 
+            confirm_popup(
+                "Suppression d'un compte",
+                "Êtes vous VRAIMENT sur ? Tout les transactions liées à ce compte seront supprimées. Je veux dire, êtes vous VRAIMENT VRAIMENT sur ? Je ne pourrais rien faire si vous le regrettez après.",
+                () => { delete_element(id); },
+                () => {}
+            );
+        },
+        () => {}
+    );
+}
+
 function delete_element(id) {
-    if (confirm("Are you sure you want to delete this account?")) {
-        if (confirm("Are you REALLY sure? It will delete all transactions linked to this account. I mean, are you REALLY REALLY sure? I can't do anything if you regret it after.")) {
-            var xhr = new XMLHttpRequest();
-            xhr.open("GET", `/api/delete/account?id=${id}`, true);
-            xhr.onload = () => {
-                if (xhr.status == 200) {
-                    new_popup("Account deleted", "success");
-                    onload();
-                }
-                else {
-                    new_popup("Error deleting account", "error")
-                }
-            }
-            xhr.send();
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", `/api/delete/account?id=${id}`, true);
+    xhr.onload = () => {
+        if (xhr.status == 200) {
+            new_popup("Account deleted", "success");
+            onload();
+        }
+        else {
+            new_popup("Error deleting account", "error")
         }
     }
+    xhr.send();
 
     setTimeout(() => {
         undo_transfer();

--- a/public/js/confirm_popup.js
+++ b/public/js/confirm_popup.js
@@ -1,0 +1,38 @@
+/**
+ * @param {string} title
+ * @param {string} message
+ * @param {Function} onConfirm
+ * @param {Function} onCancel
+ */
+function confirm_popup(title, message, onConfirm, onCancel = null) {
+
+    const overlay = document.createElement("div");
+    overlay.id = "confirm-popup-overlay";
+
+    overlay.innerHTML = `
+        <div id="confirm-popup">
+            <p id="confirm-popup-title">${title}</p>
+            <p id="confirm-popup-message">${message}</p>
+            <div id="confirm-popup-buttons">
+                <button id="confirm-popup-cancel" class="valide_button noselect">Annuler</button>
+                <button id="confirm-popup-confirm" class="valide_button noselect">Confirmer</button>
+            </div>
+        </div>
+    `;
+
+    const btnConfirm = overlay.querySelector("#confirm-popup-confirm");
+    const btnCancel = overlay.querySelector("#confirm-popup-cancel");
+
+    btnConfirm.onclick = () => { close_confirm_popup(); if (onConfirm) onConfirm(); };
+    btnCancel.onclick = () => { close_confirm_popup(); if (onCancel) onCancel(); };
+    overlay.onclick = (e) => { if (e.target.id === "confirm-popup-overlay") { close_confirm_popup(); if (onCancel) onCancel(); } };
+
+    document.body.appendChild(overlay);
+}
+
+function close_confirm_popup() {
+    let overlay = document.getElementById("confirm-popup-overlay");
+    if (!overlay) return;
+    overlay.classList.add("closing");
+    overlay.addEventListener("animationend", () => overlay.remove(), { once: true });
+}

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -61,22 +61,28 @@ function set_select_category() {
     });
 }
 
+function confirm_popup_delete_element(event_id) {
+    confirm_popup(
+        "Supprimer un évennement",
+        "Êtes-vous sûr de vouloir supprimer cet évennement ? Cette action est irréversible.",
+        () => { delete_element(event_id); },
+        () => {}
+    );
+}
+
 function delete_element(event_id) {
-    console.log(event_id);
-    if (confirm("Are you sure you want to delete this operation ?")) {
-        var xhr = new XMLHttpRequest();
-        xhr.open("GET", "/api/delete/event?id=" + event_id, true);
-        xhr.onload = () => {
-            if (xhr.status == 200) {
-                update_datasheet();
-                new_popup("Event deleted", "success");
+    var xhr = new XMLHttpRequest();
+            xhr.open("GET", "/api/delete/event?id=" + event_id, true);
+            xhr.onload = () => {
+                if (xhr.status == 200) {
+                    update_datasheet();
+                    new_popup("Event deleted", "success");
+                }
+                else {
+                    new_popup("Error deleting operation", "error");
+                }
             }
-            else {
-                new_popup("Error deleting operation", "error");
-            }
-        }
         xhr.send();
-    }
 }
 
 function update_datasheet() {
@@ -136,7 +142,7 @@ function update_datasheet() {
                     }
 
                     datasheet.children[i].children[7].innerHTML = `<img src="/assets/images/edit.png" alt="edit" class="card-button" onclick="edit_element(${events[i].id_regular_event},this)">
-                    <img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="delete_element('${events[i].id_regular_event}')">`;
+                    <img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="confirm_popup_delete_element('${events[i].id_regular_event}')">`;
                 }
             }
         }

--- a/public/js/operations.js
+++ b/public/js/operations.js
@@ -99,22 +99,29 @@ function set_select_category() {
 
 // Datasheet
 
+function confirm_popup_delete_element(element_id) {
+    confirm_popup(
+        "Supprimer une opération",
+        "Êtes-vous sûr de vouloir supprimer cette opération ? Cette action est irréversible.",
+        () => { delete_element(element_id); },
+        () => {}
+    );
+}
+
 function delete_element(element_id) {
-    if (confirm("Are you sure you want to delete this operation ?")) {
-        document.getElementById("loading-gif").style.display = "flex";
-        var xhr = new XMLHttpRequest();
-        xhr.open("GET", "/api/delete/operation?id=" + element_id, true);
-        xhr.onload = () => {
-            if (xhr.status == 200) {
-                new_popup("Operation deleted", "success");
-                update_datasheet();
+    document.getElementById("loading-gif").style.display = "flex";
+            var xhr = new XMLHttpRequest();
+            xhr.open("GET", "/api/delete/operation?id=" + element_id, true);
+            xhr.onload = () => {
+                if (xhr.status == 200) {
+                    new_popup("Operation deleted", "success");
+                    update_datasheet();
+                }
+                else {
+                    new_popup("Error deleting operation", "error")
+                }
             }
-            else {
-                new_popup("Error deleting operation", "error")
-            }
-        }
         xhr.send();
-    }
 }
 
 function datasheet_clear() {
@@ -169,7 +176,7 @@ function update_datasheet() {
                 datasheet.children[nb_operations - i - 1].children[3].innerHTML = operation_type_list[operations[i].category].title;
 
                 if (operations[i].regularity == 0) {
-                    datasheet.children[nb_operations - i - 1].children[4].innerHTML = '<img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="delete_element(' + operations[i].id_operation + ')">';
+                    datasheet.children[nb_operations - i - 1].children[4].innerHTML = '<img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="confirm_popup_delete_element(' + operations[i].id_operation + ')">';
                 }
             }
         }

--- a/public/js/verification.js
+++ b/public/js/verification.js
@@ -222,5 +222,5 @@ function open_new_operation_tab() {
     note = note.replace(/(?:\r\n|\r|\n)/g, '\\n');
     console.log(note);
 
-    window.open(`/operations?note=${note}`);
+    window.open(`/app/operations?note=${note}`);
 }

--- a/public/js/verification.js
+++ b/public/js/verification.js
@@ -190,31 +190,37 @@ function delete_list(self) {
     }
 }
 
+function confirm_popup_delete() {
+    confirm_popup(
+        "Supprimer une liste d'opération",
+        "Êtes-vous sûr de vouloir supprimer la liste d'opération ? Cette action est irréversible.",
+        () => { confirm_delete(); },
+        () => {}
+    );
+}
+
 function confirm_delete() {
     let selected = Array.from(datasheet.getElementsByClassName("to-delete"));
     if (selected.length == 0) {
         new_popup("No operation selected", "warn");
         return;
     }
-
-    if (confirm("Are you sure you want to delete these operations?") == true) {
-        selected.forEach(element => {
-            let xhr = new XMLHttpRequest();
-            xhr.open("GET", `/api/delete/operation?id=${element.getAttribute("id_operation")}`, true);
-            xhr.onload = () => {
-                if (xhr.status == 200) {
-                    element.remove();
-                    operations = operations.filter(operation => operation.id_operation != element.getAttribute("id_operation"));
-                    update_brief();
-                    new_popup("Operation deleted", "success");
-                }
-                else {
-                    new_popup("Error deleting operation", "error");
-                }
+    selected.forEach(element => {
+        let xhr = new XMLHttpRequest();
+        xhr.open("GET", `/api/delete/operation?id=${element.getAttribute("id_operation")}`, true);
+        xhr.onload = () => {
+            if (xhr.status == 200) {
+                element.remove();
+                operations = operations.filter(operation => operation.id_operation != element.getAttribute("id_operation"));
+                update_brief();
+                new_popup("Operation deleted", "success");
             }
-            xhr.send();
-        });
-    }
+            else {
+                new_popup("Error deleting operation", "error");
+            }
+        }
+        xhr.send();
+    });
 }
 
 function open_new_operation_tab() {

--- a/public/styles/confirm_popup/confirm_popup.css
+++ b/public/styles/confirm_popup/confirm_popup.css
@@ -1,0 +1,74 @@
+@keyframes overlay-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@keyframes overlay-out {
+    from { opacity: 1; }
+    to   { opacity: 0; }
+}
+
+@keyframes popup-in {
+    from { opacity: 0; transform: translateY(-20px) scale(0.95); }
+    to   { opacity: 1; transform: translateY(0)    scale(1);    }
+}
+
+@keyframes popup-out {
+    from { opacity: 1; transform: translateY(0)    scale(1);    }
+    to   { opacity: 0; transform: translateY(-20px) scale(0.95); }
+}
+
+#confirm-popup-overlay {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    animation: overlay-in 0.2s ease forwards;
+}
+
+#confirm-popup-overlay.closing {
+    animation: overlay-out 0.2s ease forwards;
+}
+
+#confirm-popup-overlay #confirm-popup {
+    background-color: #e7e7e7;
+    border-radius: 8px;
+    box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.3);
+    padding: 30px;
+    width: 90%;
+    max-width: 400px;
+    animation: popup-in 0.2s ease forwards;
+    margin: 0 20px;
+}
+
+#confirm-popup-overlay.closing #confirm-popup {
+    animation: popup-out 0.2s ease forwards;
+}
+
+#confirm-popup-overlay #confirm-popup #confirm-popup-title {
+    font-size: 18px;
+    font-weight: 700;
+    margin: 0 0 10px 0;
+    color: #333;
+}
+
+#confirm-popup-overlay #confirm-popup #confirm-popup-message {
+    font-size: 14px;
+    color: #555;
+    margin: 0 0 25px 0;
+}
+
+#confirm-popup-overlay #confirm-popup #confirm-popup-buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+#confirm-popup-overlay #confirm-popup #confirm-popup-buttons button {
+   cursor: pointer;
+   margin: 0;
+   border: 1px solid #0000006c;
+}

--- a/public/view/helpers/footer.php
+++ b/public/view/helpers/footer.php
@@ -1,4 +1,9 @@
 <footer>
+    <script src="/public/js/confirm_popup.js" type="text/javascript"></script>
+    <script src="/public/js/popup.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="/public/styles/confirm_popup/confirm_popup.css">
+    <link rel="stylesheet" href="/public/styles/popup/popup.css">
+
     <span>© 2023 Copyright :
         <a href="https://epargne-controle.oneiricforge.com/">epargne-controle.oneiricforge.com</a>
         |

--- a/public/view/helpers/header.php
+++ b/public/view/helpers/header.php
@@ -11,13 +11,9 @@
 
 	<script src="/public/js/utils.js" type="text/javascript"></script>
 	<script src="/public/js/navbar.js" type="text/javascript"></script>
-	<script src="/public/js/popup.js" type="text/javascript"></script>
-	<script src="/public/js/confirm_popup.js" type="text/javascript"></script>
 	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 	<link rel="stylesheet" href="/public/styles/header/header.css">
 	<link rel="stylesheet" href="/public/styles/generics/generics.css">
-	<link rel="stylesheet" href="/public/styles/popup/popup.css">
-	<link rel="stylesheet" href="/public/styles/confirm_popup/confirm_popup.css">
 	<title><?= $title ?></title>
 </head>
 

--- a/public/view/helpers/header.php
+++ b/public/view/helpers/header.php
@@ -12,10 +12,12 @@
 	<script src="/public/js/utils.js" type="text/javascript"></script>
 	<script src="/public/js/navbar.js" type="text/javascript"></script>
 	<script src="/public/js/popup.js" type="text/javascript"></script>
+	<script src="/public/js/confirm_popup.js" type="text/javascript"></script>
 	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 	<link rel="stylesheet" href="/public/styles/header/header.css">
 	<link rel="stylesheet" href="/public/styles/generics/generics.css">
 	<link rel="stylesheet" href="/public/styles/popup/popup.css">
+	<link rel="stylesheet" href="/public/styles/confirm_popup/confirm_popup.css">
 	<title><?= $title ?></title>
 </head>
 

--- a/public/view/index.php
+++ b/public/view/index.php
@@ -22,7 +22,7 @@
                 <?php endfor; ?>
             </div>
         </ul>
-        <a id="create-transfer" class="valide_button noselect" href="/controler/pages/operations.php">Add Operation</a>
+        <a id="create-transfer" class="valide_button noselect" href="/app/operations">Add Operation</a>
     </section>
 
     <!-- col gauche avec liste mouvement bancaire récent X dernier à partir de date ajd -->

--- a/public/view/verification.php
+++ b/public/view/verification.php
@@ -43,7 +43,7 @@
         <div class="row-field">
             <a id="add-operation" class="valide_button noselect" onclick="open_new_operation_tab()">Add missing
                 operation</a>
-            <a id="confirm-delete" class="valide_button noselect" onclick="confirm_delete()">Confirm delete</a>
+            <a id="confirm-delete" class="valide_button noselect" onclick="confirm_popup_delete()">Confirm delete</a>
         </div>
     </section>
 


### PR DESCRIPTION
Lorsque l'utilisateur veut effectuer une action irréversible, au lieu de recevoir une "alert", il aura une popup lui demandant confirmation.
La popup possède une animation fade d'apparition / disparition.
Cette popup est purement aesthetic pour remplacer la fonction "alert". Elle n'apporte aucune autre fonctionnalité.

De plus, cette PR fixe l'envoie du bouton "Add Operation" de Overview et Verification auquel le routing n'a pas été appliqué lors de son instauration.
![Uploading image.png…]()
