### PR TITLE
[T-869d3u1m7] Ajouter le nom du compte / opération dans l'alert de confirmation de suppresion

### DIFF
--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -41,7 +41,7 @@ onload = () => {
 
                         <div class="col col-4" data-label="Actions">
                             <img src="/assets/images/edit.png" alt="edit" class="card-button" onclick="edit_element(${account.id_account},this)">
-                            <img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="confirm_popup_delete_element(${account.id_account})">
+                            <img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="confirm_popup_delete_element(${account.id_account}, '${account.label}')">
                         </div>
                     </tr>`;
             });
@@ -242,14 +242,14 @@ function confirm_edit_element(label, sold, type, id) {
     }
 }
 
-function confirm_popup_delete_element(id) {
+function confirm_popup_delete_element(id, label) {
     confirm_popup(
         "Suppression d'un compte",
-        "Êtes-vous sûr de vouloir supprimer ce compte ? Cette action est irréversible.",
+        `Êtes-vous sûr de vouloir supprimer le compte <strong>${label}</strong> ? Cette action est irréversible.`,
         () => { 
             confirm_popup(
                 "Suppression d'un compte",
-                "Êtes vous VRAIMENT sur ? Tout les transactions liées à ce compte seront supprimées. Je veux dire, êtes vous VRAIMENT VRAIMENT sur ? Je ne pourrais rien faire si vous le regrettez après.",
+                `Êtes vous VRAIMENT sur ? Tout les transactions liées à <strong>${label}</strong> seront supprimées. Je veux dire, êtes vous VRAIMENT VRAIMENT sur ? Je ne pourrais rien faire si vous le regrettez après.`,
                 () => { delete_element(id); },
                 () => {}
             );

--- a/public/js/confirm_popup.js
+++ b/public/js/confirm_popup.js
@@ -11,7 +11,7 @@ function confirm_popup(title, message, onConfirm, onCancel = null) {
 
     overlay.innerHTML = `
         <div id="confirm-popup">
-            <p id="confirm-popup-title">${title}</p>
+            <p id="confirm-popup-title">${escapeHTML(title)}</p>
             <p id="confirm-popup-message">${message}</p>
             <div id="confirm-popup-buttons">
                 <button id="confirm-popup-cancel" class="valide_button noselect">Annuler</button>

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -62,9 +62,10 @@ function set_select_category() {
 }
 
 function confirm_popup_delete_element(event_id) {
+    const event = events.find(e => e.id_regular_event == event_id);
     confirm_popup(
-        "Supprimer un évennement",
-        "Êtes-vous sûr de vouloir supprimer cet évennement ? Cette action est irréversible.",
+        "Supprimer un évènement",
+        `Êtes-vous sûr de vouloir supprimer l'évènement ${bold(event.label)} ? Cette action est irréversible.`,
         () => { delete_element(event_id); },
         () => {}
     );
@@ -142,7 +143,7 @@ function update_datasheet() {
                     }
 
                     datasheet.children[i].children[7].innerHTML = `<img src="/assets/images/edit.png" alt="edit" class="card-button" onclick="edit_element(${events[i].id_regular_event},this)">
-                    <img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="confirm_popup_delete_element('${events[i].id_regular_event}')">`;
+                    <img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="confirm_popup_delete_element(${events[i].id_regular_event})">`;
                 }
             }
         }

--- a/public/js/operations.js
+++ b/public/js/operations.js
@@ -100,9 +100,10 @@ function set_select_category() {
 // Datasheet
 
 function confirm_popup_delete_element(element_id) {
+    const op = operations.find(o => o.id_operation == element_id);
     confirm_popup(
         "Supprimer une opération",
-        "Êtes-vous sûr de vouloir supprimer cette opération ? Cette action est irréversible.",
+        `Êtes-vous sûr de vouloir supprimer l'opération ${bold(op.label)} ? Cette action est irréversible.`,
         () => { delete_element(element_id); },
         () => {}
     );
@@ -176,7 +177,7 @@ function update_datasheet() {
                 datasheet.children[nb_operations - i - 1].children[3].innerHTML = operation_type_list[operations[i].category].title;
 
                 if (operations[i].regularity == 0) {
-                    datasheet.children[nb_operations - i - 1].children[4].innerHTML = '<img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="confirm_popup_delete_element(' + operations[i].id_operation + ')">';
+                    datasheet.children[nb_operations - i - 1].children[4].innerHTML = `<img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="confirm_popup_delete_element(${operations[i].id_operation})">`;
                 }
             }
         }

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -6,3 +6,24 @@
 function formatDateToString(date) {
     return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
 }
+
+/**
+ * @param {string} str
+ * @returns {string}
+ */
+function escapeHTML(str) {
+    return String(str)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+/**
+ * @param {string} str
+ * @returns {string}
+ */
+function bold(str) {    // Bold function if needed
+    return `<strong>${escapeHTML(str)}</strong>`;
+}


### PR DESCRIPTION
Lors de la suppression d'un compte, le nom du compte s'affiche en gras dans la popup de confirmation.
Ne pas prendre en compte l'échelle des éléments à l'image. Il y a un zoom sur le navigateur pour facilité la lisibilité sans perte de clarté.

_Aucun ajout de fonctionnalité utilisateur n'a été ajouté._
<img width="837" height="335" alt="image" src="https://github.com/user-attachments/assets/ddedcdf9-28ff-4d54-8efb-7f064d386dc2" />
<img width="837" height="393" alt="image" src="https://github.com/user-attachments/assets/ebbacde8-5c06-4275-81c8-339aa1ff7e61" />



