### PR TITLE
[T-869dd3d89] Bouton sur une carte de compte déplace la carte

### DIFF
--- a/database/connexion.php
+++ b/database/connexion.php
@@ -23,7 +23,7 @@ global $db;
 
 // Use env variables to connect to the database
 try {
-    $cnx = 'mysql:host='.$DB_HOST.';port='.$DB_PORT.';dbname='.$DB_NAME.'';
+    $cnx = 'mysql:host='.$DB_HOST.';port='.$DB_PORT.';dbname='.$DB_NAME.';charset=utf8mb4';
     $options = array(
         PDO::MYSQL_ATTR_SSL_CA => $_SERVER['DOCUMENT_ROOT'] . "../../../../etc/ssl/certs/ca-certificates.crt", // TODO: Change this path
     );

--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -8,8 +8,19 @@ const create_account_button = document.getElementById("create-account");
 const total_sold = document.getElementById("total-sold");
 let transfer_data = [null, null];
 
-window.addEventListener('resize', undo_transfer());
 function f_onload() { onload(); }
+
+// Reposition selected cards on resize/zoom
+window.addEventListener('resize', reposition_transfer_cards);
+
+// Zoom doesn't always fire 'resize'; observe the table (changes on zoom, not on transform) to avoid a loop
+window.addEventListener('DOMContentLoaded', () => {
+    let target = document.querySelector(".responsive-table");
+    if (target && window.ResizeObserver) {
+        let observer = new ResizeObserver(() => reposition_transfer_cards());
+        observer.observe(target);
+    }
+});
 
 onload = () => {
     datasheet.innerHTML = "";
@@ -59,8 +70,7 @@ onload = () => {
 
 function manage_account_transfer(id) {
     if ((transfer_data[0] == id) || (transfer_data[1] == id)) {
-        document.getElementById("card-" + id).style = "";
-
+        transfer_animation_off(id);
         if (transfer_data[0] == id) {
             transfer_data[0] = null;
         }
@@ -80,21 +90,48 @@ function manage_account_transfer(id) {
     document.getElementById("transfer-field").disabled = ((transfer_data[0] == null) || (transfer_data[1] == null));
 }
 
-function transfer_animation_on(id, postion) {
+// animate: true on click (slide), false on zoom (instant, avoids jitter)
+function transfer_animation_on(id, postion, animate = true) {
     let card = document.getElementById("card-" + id);
 
-    // get postion balise from-account
-    let from_account_position = document.getElementById(`selected-account-${postion}`).getBoundingClientRect();
+    if (!animate) {
+        card.style.transition = "none";
+    }
+
+    // Reset + set final width before measuring so the offset is correct
+    card.style.transform = "";
+    card.style.width = "90%";
+    card.offsetWidth; // force reflow
+
+    let slot_position = document.getElementById(`selected-account-${postion}`).getBoundingClientRect();
     let card_position = card.getBoundingClientRect();
 
-    // make diff
-    let x = from_account_position.x - card_position.x;
-    let y = from_account_position.y - card_position.y;
+    let x = slot_position.x - card_position.x;
+    let y = slot_position.y - card_position.y;
 
     card.style.transform = `translate(${x}px, ${y}px)`;
 
-    // Adapte size
-    card.style.width = "90%";
+    if (!animate) {
+        card.offsetWidth;
+        card.style.transition = "";
+    }
+}
+
+// Reposition selected cards without animation (on zoom/resize)
+function reposition_transfer_cards() {
+    if (transfer_data[0] != null) {
+        transfer_animation_on(transfer_data[0], 0, false);
+    }
+    if (transfer_data[1] != null) {
+        transfer_animation_on(transfer_data[1], 1, false);
+    }
+}
+
+// Reset card to its original position
+function transfer_animation_off(id) {
+    let card = document.getElementById("card-" + id);
+    card.style.transform = "";
+    card.style.width = "";
 }
 
 function process_transfer() {
@@ -147,10 +184,10 @@ function get_account_shortname() {
 
 function undo_transfer() {
     if (transfer_data[0] != null) {
-        document.getElementById("card-" + transfer_data[0]).style = "";
+        transfer_animation_off(transfer_data[0]);
     }
     if (transfer_data[1] != null) {
-        document.getElementById("card-" + transfer_data[1]).style = "";
+        transfer_animation_off(transfer_data[1]);
     }
     transfer_data = [null, null];
     document.getElementById("transfer-field").disabled = true;

--- a/public/js/accounts.js
+++ b/public/js/accounts.js
@@ -41,8 +41,8 @@ onload = () => {
                         <div class="col col-3" data-label="Type">${account.type ? "Savings account" : "Checking account"}</div>
 
                         <div class="col col-4" data-label="Actions">
-                            <img src="/assets/images/edit.png" alt="edit" class="card-button" onclick="edit_element(${account.id_account},this)">
-                            <img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="confirm_popup_delete_element(${account.id_account}, '${account.label}')">
+                            <img src="/assets/images/edit.png" alt="edit" class="card-button" onclick="edit_element(event, ${account.id_account}, this)">
+                            <img src="/assets/images/trash.png" alt="delete" class="card-button" onclick="confirm_popup_delete_element(event, ${account.id_account}, '${account.label}')">
                         </div>
                     </tr>`;
             });
@@ -202,7 +202,8 @@ function cancel_create_account() {
     create_account_button.style.display = "";
 }
 
-function edit_element(id, element) {
+function edit_element(event, id, element) {
+    event.stopPropagation();
     card = element.parentNode.parentNode;
     card.classList.add("editing-row");
 
@@ -245,7 +246,8 @@ function confirm_edit_element(label, sold, type, id) {
     }
 }
 
-function confirm_popup_delete_element(id, label) {
+function confirm_popup_delete_element(event, id, label) {
+    event.stopPropagation();
     confirm_popup(
         "Suppression d'un compte",
         `Êtes-vous sûr de vouloir supprimer le compte <strong>${label}</strong> ? Cette action est irréversible.`,

--- a/public/styles/pages/accounts/accounts.css
+++ b/public/styles/pages/accounts/accounts.css
@@ -45,6 +45,11 @@
   margin: 10px 0;
 }
 
+.responsive-table .table-row[style*="transform"] {
+  position: relative;
+  z-index: 10;
+}
+
 #create-account-field {
   display: none;
   background-color: #f5f5f5;
@@ -85,4 +90,4 @@
   .back-table-row {
     height: 5px !important;
   }
-}/*# sourceMappingURL=accounts.css.map */
+}


### PR DESCRIPTION
Les bouton "edit" et "supprimer" un account, ne déplace plus la card de l'account pour un transfert.

Quand une card est sélectionnée pour un transfert, elle glisse vers la zone Transfer via transform: translate(x, y). Ce décalage était calculé une seule fois (au clic) et figé en pixels, donc au zoom il devenait faux et la card se décalait.

Correction : un ResizeObserver détecte le changement de taille au zoom et recalcule le décalage à chaque fois, pour que la card reste bien positionnée. Le recalcul se fait sans animation (instantané) pour éviter un effet de tremblement, alors que le clic garde l'animation de glissement. L'observer cible le tableau et non la zone Transfer, afin d'éviter une boucle de repositionnement.

L'animation de déplacement ne se fait pas UNIQUEMENT lorsque l'on zoom pendant le déplacement. Mais l'account reste bien sélectionner.

### Autre modification
L'ajout de l'utilisation des emojis dans les emplacement de chaine de caractères. Aucune mise à jour de bdd nécéssaire.
Si necessaire, voici la commande : 
```ALTER DATABASE epargne-controle CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;```