### PR TITLE
FIX | Auto Scroll Operation Page

### DIFF
--- a/lang/English.json
+++ b/lang/English.json
@@ -52,7 +52,14 @@
     "operations": {
         "title": "Operations",
         "nav": "Operations",
-        "select_account": "Select an account",
+        "filters": {
+            "search_label": "Search a label...",
+            "all_accounts": "All accounts",
+            "all_types": "All types",
+            "balance": "Balance"
+        },
+        "select_account": "Select an account on wich to add operation",
+        "account_list": "Select an account",
         "add_operation": "Add an operation",
         "amount": "Amount",
         "date": "Date",

--- a/lang/Français.json
+++ b/lang/Français.json
@@ -52,7 +52,14 @@
     "operations": {
         "title": "Opérations",
         "nav": "Opérations",
-        "select_account": "Sélectionnez un compte",
+        "filters": {
+            "search_label": "Rechercher un label...",
+            "all_accounts": "Tous les comptes",
+            "all_types": "Tous les types",
+            "balance": "Balance"
+        },
+        "select_account": "Sélectionnez un compte sur lequel ajouter une opération",
+        "account_list": "Choissez un compte",
         "add_operation": "Ajouter une opération",
         "amount": "Montant",
         "date": "Date",

--- a/public/js/navbar.js
+++ b/public/js/navbar.js
@@ -1,50 +1,29 @@
+let dark = document.getElementById("dark");
+let navbar = document.getElementById("side-menu");
+
+let shadow_color_dark = "#000000ab";
+let shadow_color_light = "#00000000";
 
 function show_navbar() {
-    let dark = document.getElementById("dark");
-    let navbar = document.getElementById("side-menu");
 
     navbar.style.left = "0px";
-    dark.style.backgroundColor = "#000000ab";
+    dark.style.backgroundColor = shadow_color_dark;
     dark.style.zIndex = "90";
 
-    setTimeout(function () {
-        dark.addEventListener("click", hide_navbar);
-    }, 1);
+    dark.addEventListener("click", hide_navbar);
 }
 
 function hide_navbar() {
-    let dark = document.getElementById("dark");
-    let navbar = document.getElementById("side-menu");
 
     navbar.style.left = "-175px";
-    dark.style.backgroundColor = "#00000000";
+    dark.style.backgroundColor = shadow_color_light;
     dark.style.zIndex = "-1";
 
     dark.removeEventListener("click", hide_navbar);
 }
 
-// Security: resizes the window more than 768px, navbar will be reset
-window.addEventListener("resize", function () {
-    if (window.innerWidth > 768) {
-        let dark = document.getElementById("dark");
-        let navbar = document.getElementById("side-menu");
-
-        navbar.style.left = "0px";
-        dark.style.backgroundColor = "#00000000";
-        dark.style.zIndex = "-1";
-
-        document.body.removeEventListener("click", hide_navbar);
-    }
-});
-
 // Security: close navbar when the window is resized
-window.addEventListener("resize", function () {
-    if (window.innerWidth < 768) {
-        let dark = document.getElementById("dark");
-        let navbar = document.getElementById("side-menu");
-
-        navbar.style.left = "-175px";
-        dark.style.backgroundColor = "#00000000";
-        dark.style.zIndex = "-1";
-    }
+window.addEventListener("resize", () => {
+    hide_navbar()
+    if (window.innerWidth > 768) navbar.style.left = "0px";
 });

--- a/public/js/operations.js
+++ b/public/js/operations.js
@@ -49,7 +49,6 @@ onload = () => {
 }
 
 function sync_account_selection() {
-
     document.getElementById("loading-gif").style.display = "flex";
     balance_view.value = account_list.value;
     selected_account = accounts.find(account => account.id_account == account_list.value)
@@ -96,6 +95,8 @@ function load_preloaded_data() {
     operation_type_list = window.OPERATION_TYPES || [];
     accounts = window.ACCOUNTS || [];
 
+    setup_filter_type();
+
     if (accounts.length == 0) {
         new_popup("There is no account yet", "info");
         document.getElementById("add-field").disabled = true;
@@ -103,6 +104,15 @@ function load_preloaded_data() {
     }
 
     update_datasheet();
+}
+
+function setup_filter_type() {
+    const default_option = filter_type.querySelector('option[value=""]').outerHTML;
+    filter_type.innerHTML = default_option;
+
+    operation_type_list.forEach(operation_type => {
+        filter_type.innerHTML += `<option value="${operation_type.id}">${translate_category(operation_type.title)}</option>`;
+    });
 }
 
 function set_select_category() {

--- a/public/js/operations.js
+++ b/public/js/operations.js
@@ -49,6 +49,7 @@ onload = () => {
 }
 
 function sync_account_selection() {
+
     document.getElementById("loading-gif").style.display = "flex";
     balance_view.value = account_list.value;
     selected_account = accounts.find(account => account.id_account == account_list.value)
@@ -265,14 +266,14 @@ function creating_operation_pannel() {
     set_select_category();
 
     if (account_list.value > 0) {
-        add_field.style.visibility = "visible";
-        add_field.style.transform = "translate(0, 0)";
-        add_field.style.opacity = "1";
+        add_field.style.display = "flex";
+        requestAnimationFrame(() => {
+            add_field.classList.add("is-visible");
+        });
     }
     else {
-        add_field.style.transform = "translate(50px, 0)";
-        add_field.style.opacity = "0";
-        add_field.style.visibility = "hidden";
+        add_field.classList.remove("is-visible");
+        add_field.style.display = "none";
     }
 }
 

--- a/public/styles/generics/generics.css
+++ b/public/styles/generics/generics.css
@@ -1,12 +1,12 @@
 body {
-  overflow-x: hidden !important;
+  display: flex;
+  flex-direction: column;
   position: relative;
-  height: 100%;
-  margin: 0;
+  min-height: 100vh;
+  margin: 0 0 0 175px;
   padding: 0;
   font-family: "lato", sans-serif;
   background-color: #e7e7e7;
-  margin-left: 175px;
 }
 
 .container {

--- a/public/styles/header/header.css
+++ b/public/styles/header/header.css
@@ -2,8 +2,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  right: 0;
-  width: auto;
+  width: 100vw;
   height: 100vh;
   transition: all 0.3s ease-in-out;
   background-color: rgba(0, 0, 0, 0);
@@ -113,7 +112,7 @@ footer {
   box-sizing: border-box;
   padding: 5px 10px;
   background-color: #d4d4d4;
-  z-index: 50;
+  z-index: 10;
 }
 
 @media all and (max-width: 767px) {

--- a/public/styles/header/header.css
+++ b/public/styles/header/header.css
@@ -105,11 +105,9 @@ header #navicon {
 }
 
 footer {
-  position: fixed;
-  bottom: 0;
-  left: 175px;
-  right: 0;
+  margin-top: auto;
   box-sizing: border-box;
+  width: 100%;
   padding: 5px 10px;
   background-color: #d4d4d4;
   z-index: 10;
@@ -121,8 +119,5 @@ footer {
   }
   #navicon {
     display: block !important;
-  }
-  footer {
-    left: 0;
   }
 }

--- a/public/styles/header/header.css
+++ b/public/styles/header/header.css
@@ -2,7 +2,8 @@
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
+  right: 0;
+  width: auto;
   height: 100vh;
   transition: all 0.3s ease-in-out;
   background-color: rgba(0, 0, 0, 0);
@@ -107,7 +108,9 @@ header #navicon {
 footer {
   position: fixed;
   bottom: 0;
-  width: 100%;
+  left: 175px;
+  right: 0;
+  box-sizing: border-box;
   padding: 5px 10px;
   background-color: #d4d4d4;
   z-index: 50;
@@ -120,4 +123,7 @@ footer {
   #navicon {
     display: block !important;
   }
-}/*# sourceMappingURL=header.css.map */
+  footer {
+    left: 0;
+  }
+}

--- a/public/styles/pages/operations/operations.css
+++ b/public/styles/pages/operations/operations.css
@@ -270,12 +270,17 @@
   .responsive-table {
     position: relative;
   }
+  .responsive-table .table-row {
+    position: relative;
+    z-index: 1;
+  }
   #balance-footer {
     position: absolute;
     top: 100%;
     left: 0;
     right: 0;
     box-sizing: border-box;
+    box-shadow: inset 0 9px 9px -9px rgba(0, 0, 0, 0.12);
   }
 }
 /*# sourceMappingURL=operations.css.map */

--- a/public/styles/pages/operations/operations.css
+++ b/public/styles/pages/operations/operations.css
@@ -20,7 +20,7 @@
   align-items: center;
 }
 #add-pannel #add-form {
-  justify-content: center;
+  justify-content: flex-start;
   flex-direction: column;
   align-items: center;
   display: flex;
@@ -28,13 +28,11 @@
   height: 100%;
 }
 #add-pannel #add-form #add-field {
-  display: flex;
-  visibility: hidden;
+  display: none;
   opacity: 0;
-  transition: opacity 0.3s, transform 0.3s, visibility 0.3s;
-  transform: translate(50px, 0);
+  transition: opacity 0.3s, transform 0.3s;
+  transform: translateX(40px);
   width: 80%;
-  height: 80%;
   flex-direction: column;
   justify-content: space-evenly;
   border: 0px;
@@ -53,6 +51,10 @@
 #add-pannel #add-form #add-field .flex-div {
   display: flex;
   flex-direction: row;
+}
+#add-pannel #add-form #add-field.is-visible {
+  opacity: 1;
+  transform: translateX(0);
 }
 
 .responsive-table .col-1 {
@@ -100,19 +102,33 @@
     flex-direction: column;
   }
 
-  .responsive-table:has(#balance-footer) {
-    position: relative;
-  }
-  #balance-footer {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    width: 100%;
-    box-sizing: border-box;
-  }
-
   #add-pannel {
     margin-top: 30px;
+    height: 398px;
+  }
+  #add-pannel #add-form #add-field {
+    width: auto;
+    align-self: stretch;
+    margin: 15px;
+    min-width: 0;
+    min-height: 0;
+    transform: translateY(12px);
+  }
+  #add-pannel #add-form #add-field.is-visible {
+    transform: translateY(0);
+  }
+  #add-pannel #add-form #add-field input,
+  #add-pannel #add-form #add-field select {
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+  }
+  #add-pannel #add-form #add-field .flex-div {
+    gap: 10px;
+  }
+  #add-pannel #add-form #add-field .flex-div > div {
+    min-width: 0;
+    flex: 1;
   }
 
   #search-filters {
@@ -229,10 +245,13 @@
   font-style: italic;
 }
 
+/* Style de base du solde — tous écrans (en flux, animé par max-height) */
 #balance-footer {
+  position: relative;
+  z-index: 0;
   padding: 0 16px;
   background-color: #f5f5f5;
-  border-radius: 0 0 5px 5px;
+  border-radius: 0 0 10px 10px;
   font-style: italic;
   color: #444;
   font-size: 0.9em;
@@ -247,4 +266,16 @@
   padding: 10px 16px;
 }
 
+@media all and (max-width: 767px) {
+  .responsive-table {
+    position: relative;
+  }
+  #balance-footer {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    box-sizing: border-box;
+  }
+}
 /*# sourceMappingURL=operations.css.map */

--- a/public/styles/pages/verification/verification.css
+++ b/public/styles/pages/verification/verification.css
@@ -60,4 +60,10 @@
 #month-brief #total-income {
   color: #308d05;
   font-weight: bold;
-}/*# sourceMappingURL=verification.css.map */
+}
+
+@media all and (max-width: 767px) {
+  #notes-pannel {
+    display: none;
+  }
+}

--- a/public/styles/table/table.css
+++ b/public/styles/table/table.css
@@ -13,6 +13,9 @@
   margin-bottom: 5px;
   height: 20px;
 }
+.responsive-table li:last-child {
+  margin-bottom: 0;
+}
 .responsive-table .table-header {
   background-color: #95A5A6;
   font-size: 14px;
@@ -20,7 +23,8 @@
   letter-spacing: 0.03em;
 }
 .responsive-table .table-row {
-  transition: transform 0.3s ease, width 0.3s ease 0.1s;
+  position: relative;
+  z-index: 1;
   background-color: #ffffff;
   box-shadow: 0px 0px 9px 0px rgba(0, 0, 0, 0.1);
 }

--- a/public/styles/table/table.scss
+++ b/public/styles/table/table.scss
@@ -23,6 +23,8 @@ $phone-width: 767px;
     }
 
     .table-row {
+        position: relative;
+        z-index: 1;
         transition: transform 0.3s ease, width 0.3s ease 0.1s;
         background-color: #ffffff;
         box-shadow: 0px 0px 9px 0px rgba(0, 0, 0, 0.1);

--- a/public/view/accounts.php
+++ b/public/view/accounts.php
@@ -59,8 +59,6 @@
     </section>
 </section>
 
-<br>
-<br>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="/public/js/accounts.js" type="text/javascript"></script>

--- a/public/view/analytics.php
+++ b/public/view/analytics.php
@@ -44,9 +44,6 @@
 
 </section>
 
-<br>
-<br>
-
 <script src="https://cdn.jsdelivr.net/npm/chart.js@^4"></script>
 <script src="https://cdn.jsdelivr.net/npm/moment@^2"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@^1"></script>

--- a/public/view/budget.php
+++ b/public/view/budget.php
@@ -101,8 +101,6 @@
 
 </section>
 
-<br>
-<br>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js@^4"></script>
 <script src="https://cdn.jsdelivr.net/npm/moment@^2"></script>

--- a/public/view/events.php
+++ b/public/view/events.php
@@ -75,8 +75,6 @@
 
 </section>
 
-<br>
-<br>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="/public/js/events.js" type="text/javascript"></script>

--- a/public/view/helpers/footer.php
+++ b/public/view/helpers/footer.php
@@ -1,6 +1,7 @@
 <footer>
     <script src="/public/js/confirm_popup.js" type="text/javascript"></script>
     <script src="/public/js/popup.js" type="text/javascript"></script>
+    <script src="/public/js/navbar.js" type="text/javascript"></script>
     <link rel="stylesheet" href="/public/styles/confirm_popup/confirm_popup.css">
     <link rel="stylesheet" href="/public/styles/popup/popup.css">
 

--- a/public/view/helpers/header.php
+++ b/public/view/helpers/header.php
@@ -12,7 +12,6 @@
 
 	<script>window.APP_LANG = <?= get_lang_json() ?>;</script>
 	<script src="/public/js/utils.js" type="text/javascript"></script>
-	<script src="/public/js/navbar.js" type="text/javascript"></script>
 	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 	<link rel="stylesheet" href="/public/styles/header/header.css">
 	<link rel="stylesheet" href="/public/styles/generics/generics.css">

--- a/public/view/index.php
+++ b/public/view/index.php
@@ -40,8 +40,6 @@
     </section>
 </section>
 
-<br>
-<br>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js@^4"></script>
 <script src="https://cdn.jsdelivr.net/npm/moment@^2"></script>

--- a/public/view/operations.php
+++ b/public/view/operations.php
@@ -94,8 +94,6 @@
     </section>
 </section>
 
-<br>
-<br>
 
 <script>
     window.ACCOUNTS = <?= json_encode($accounts, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;

--- a/public/view/operations.php
+++ b/public/view/operations.php
@@ -6,25 +6,22 @@
 
         <section id="search-filters">
             <div id="search-filters-left">
-                <input type="text" name="search-label" id="search-label" placeholder="Rechercher un label...">
+                <input type="text" name="search-label" id="search-label" placeholder="<?= trans('operations.filters.search_label') ?>">
                 <button type="button" id="filter-toggle"><img src="/assets/images/filter.png" alt="filter"></button>
             </div>
             <div id="filter-dropdown">
                 <select name="balance-view" id="balance-view">
-                    <option value="0">Tous les comptes</option>
+                    <option value="0"><?= trans('operations.filters.all_accounts') ?></option>
                     <?php foreach ($accounts as $account): ?>
                         <option value="<?= (int) $account['id_account'] ?>"><?= htmlspecialchars($account['label']) ?></option>
                     <?php endforeach; ?>
                 </select>
                 <select name="filter-type" id="filter-type">
-                    <option value="">Tous les types</option>
-                    <?php foreach ($operation_types as $type): ?>
-                        <option value="<?= (int) $type['id'] ?>"><?= htmlspecialchars($type['title']) ?></option>
-                    <?php endforeach; ?>
+                    <option value=""><?= trans('operations.filters.all_types') ?></option>
                 </select>
                 <input type="date" name="date-to-search" id="date-to-search">
             </div>
-            <input type="text" name="balance" id="balance" placeholder="Balance" disabled style="display:none;">
+            <input type="text" name="balance" id="balance" placeholder="<?= trans('operations.filters.balance') ?>" disabled style="display:none;">
         </section>
 
         <ul class="responsive-table">
@@ -60,7 +57,7 @@
             <div id="account_selection">
                 <p><?= trans('operations.select_account') ?></p>
                 <select name="selected-account" id="selected-account">
-                    <option value="0"><?= trans('operations.select_account') ?></option>
+                    <option value="0"><?= trans('operations.account_list') ?></option>
                     <?php foreach ($accounts as $account): ?>
                         <option value="<?= (int) $account['id_account'] ?>"><?= htmlspecialchars($account['label']) ?></option>
                     <?php endforeach; ?>

--- a/public/view/operations.php
+++ b/public/view/operations.php
@@ -101,8 +101,6 @@
 <br>
 
 <script>
-    // Données pré-chargées par le serveur (voir controler/pages/operations.php).
-    // Évite deux requêtes API au chargement de la page.
     window.ACCOUNTS = <?= json_encode($accounts, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
     window.OPERATION_TYPES = <?= json_encode($operation_types, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
 </script>

--- a/public/view/verification.php
+++ b/public/view/verification.php
@@ -54,8 +54,6 @@
     </section>
 </section>
 
-<br>
-<br>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="/public/js/verification.js" type="text/javascript"></script>


### PR DESCRIPTION
### **Les bugs corrigés et leurs causes**

1. Footer trop large + scroll horizontal en mobile (pages operations, analytics, events)
Des éléments débordaient à droite de l'écran (l'overlay #dark, le panneau #add-field), ce qui élargissait la "zone de référence" du navigateur. Le footer, en position: fixed avec width: 100%, se calait sur cette zone élargie et dépassait l'écran. Le overflow-x: hidden qui existait sur le body ne suffisait pas car un élément fixed y échappe.
Correctifs : ancrage du footer et de #dark avec left/right au lieu de width: 100%, et ajout d'un overflow-x: hidden au niveau racine (html) comme sécurité.

2. Animation du panneau qui débordait (operations)
Le panneau d'ajout utilisait transform: translate(50px, 0) (50 pixels fixes hors écran). Remplacé par translateX(110%) + overflow: hidden sur le conteneur : même effet de glissement visuel, mais sans jamais sortir de l'écran.

3. Box beige mal dimensionnée en mobile (operations)
Débordaitsur les côtés une fois un compte sélectionné. La vraie cause du débordement : les champs de saisie avaient une largeur fixe de 323px qui forçait la box à s'élargir.
Correctifs : box en flex: 1 (remplit la hauteur), champs rendus fluides (width: 100%) et min-width: 0 pour qu'ils puissent rétrécir. Résultat : marges uniformes de 15px tout autour.

4. Footer mal placé en version PC
Le footer passait sous le menu latéral (copyright caché). Corrigé : left: 175px en desktop (après le menu), left: 0 en mobile (menu masqué).

<img width="757" height="936" alt="image" src="https://github.com/user-attachments/assets/a9cc036f-0d9e-4ef9-8ac9-537448ce375a" />
