### PR TITLE
 [T-869d3tux8] Authentification par Jwt

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -7,3 +7,7 @@ DB_NAME=TheIncredibleTable
 MAIL_CONTACT=mail.exemple@exemple.com
 MAIL_SENDER=no-reply@example.com
 MAIL_SENDER_PASSWORD=app-specific-password
+
+# Secret used to sign auth JWTs. Generate one with:
+#   php -r "echo bin2hex(random_bytes(32));"
+JWT_SECRET=change-me-to-a-64-hex-random-string

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
-        "phpmailer/phpmailer": "^7.1"
+        "phpmailer/phpmailer": "^7.1",
+        "firebase/php-jwt": "^7.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,74 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7173d6a700b02b111e51b703acd8c8e",
+    "content-hash": "118f5ed54f4b55c656f0114b9a7ec908",
     "packages": [
+        {
+            "name": "firebase/php-jwt",
+            "version": "v7.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
+                "phpseclib/phpseclib": "~3.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present",
+                "phpseclib/phpseclib": "Support PS256 (RSASSA-PSS) signatures"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/googleapis/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.1.0"
+            },
+            "time": "2026-06-11T17:54:14+00:00"
+        },
         {
             "name": "phpmailer/phpmailer",
             "version": "v7.1.1",

--- a/controler/helpers/auth.php
+++ b/controler/helpers/auth.php
@@ -1,22 +1,234 @@
 <?php
 
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once($_SERVER['DOCUMENT_ROOT'] . '/database/connexion.php');
 require_once($_SERVER['DOCUMENT_ROOT'] . '/database/api/v1/apiUtils.php');
 require_once($_SERVER['DOCUMENT_ROOT'] . '/controler/helpers/lang.php');
 
-function requireLogin()
+/**
+ * Stateless authentication backed by a signed JWT stored in an httpOnly cookie.
+ *
+ * Token claims:
+ *   sub   int     user id (id_user)
+ *   email string  user email (stable, used for account-scoped queries)
+ *   lvl   int     account_level (0 = user, 1 = super user)
+ *   acc   int[]   ids of the bank accounts the user owns
+ *   iat   int     issued-at timestamp
+ *   exp   int     expiry timestamp
+ *
+ * username and language are intentionally NOT in the token: they are mutable
+ * preferences and are read from the database per request (see lang.php).
+ */
+class Auth
 {
-    if (session_status() !== PHP_SESSION_ACTIVE) session_start();
-    if (!isset($_SESSION['email'])) {
-        $_SESSION['redirect'] = $_SERVER['REQUEST_URI'];
-        header('Location: /app/login');
+    private const COOKIE_NAME = 'auth_token';
+    private const ALGO        = 'HS256';
+    private const TTL         = 604800; // 7 days, in seconds
+
+    /** @var array|null Decoded claims for the current request (cached). */
+    private static ?array $claims = null;
+    private static bool $verified = false;
+
+    private static function secret(): string
+    {
+        $secret = getenv('JWT_SECRET');
+        if ($secret === false || $secret === '') {
+            error_log('[Auth] JWT_SECRET is not set');
+            http_response_code(500);
+            exit('Server authentication is misconfigured.');
+        }
+        return $secret;
+    }
+
+    /**
+     * Verify the request cookie and return the claims, or null when the caller
+     * is not authenticated (missing / invalid / expired token). Cached.
+     */
+    public static function verify(): ?array
+    {
+        if (self::$verified) {
+            return self::$claims;
+        }
+        self::$verified = true;
+
+        $token = $_COOKIE[self::COOKIE_NAME] ?? '';
+        if ($token === '') {
+            return self::$claims = null;
+        }
+
+        try {
+            $decoded = (array) JWT::decode($token, new Key(self::secret(), self::ALGO));
+            $decoded['acc'] = array_map('intval', (array) ($decoded['acc'] ?? []));
+            self::$claims = $decoded;
+        } catch (\Throwable $e) {
+            self::$claims = null;
+        }
+
+        return self::$claims;
+    }
+
+    public static function isAuthenticated(): bool
+    {
+        return self::verify() !== null;
+    }
+
+    /** Build claims from the database for $email and set the cookie. */
+    public static function issueForUser(string $email): void
+    {
+        global $db;
+
+        $query = $db->prepare('SELECT id_user, account_level FROM user WHERE email = :email');
+        $query->execute(['email' => $email]);
+        $user = $query->fetch(PDO::FETCH_ASSOC);
+
+        if (!$user) {
+            sendAPIResponse(404, 'User not found', []);
+        }
+
+        $query = $db->prepare('SELECT id_account FROM bank_account WHERE user_email = :email');
+        $query->execute(['email' => $email]);
+        $accountIds = array_map('intval', $query->fetchAll(PDO::FETCH_COLUMN));
+
+        $now = time();
+        $claims = [
+            'sub'   => (int) $user['id_user'],
+            'email' => $email,
+            'lvl'   => (int) $user['account_level'],
+            'acc'   => $accountIds,
+            'iat'   => $now,
+            'exp'   => $now + self::TTL,
+        ];
+
+        self::writeCookie(JWT::encode($claims, self::secret(), self::ALGO), $claims['exp']);
+
+        // Keep the current-request cache in sync so accessors see fresh data.
+        self::$claims   = $claims;
+        self::$verified = true;
+    }
+
+    /** Re-issue the cookie for the current user (e.g. after the account list changes). */
+    public static function refresh(): void
+    {
+        $email = self::email();
+        if ($email !== null) {
+            self::issueForUser($email);
+        }
+    }
+
+    /** Clear the authentication cookie (logout). */
+    public static function clear(): void
+    {
+        setcookie(self::COOKIE_NAME, '', self::cookieOptions(time() - 3600));
+        unset($_COOKIE[self::COOKIE_NAME]);
+        self::$claims   = null;
+        self::$verified = true;
+    }
+
+    public static function userId(): ?int
+    {
+        $c = self::verify();
+        return $c !== null ? (int) $c['sub'] : null;
+    }
+
+    public static function email(): ?string
+    {
+        $c = self::verify();
+        return $c['email'] ?? null;
+    }
+
+    public static function level(): int
+    {
+        $c = self::verify();
+        return (int) ($c['lvl'] ?? 0);
+    }
+
+    /** @return int[] */
+    public static function accountIds(): array
+    {
+        $c = self::verify();
+        return $c['acc'] ?? [];
+    }
+
+    /**
+     * True when the current user owns account $id. Checks the signed token
+     * first, then falls back to the database (the token may be stale for an
+     * account created within the same session before a refresh).
+     */
+    public static function ownsAccount(int $id): bool
+    {
+        if ($id <= 0) {
+            return false;
+        }
+        if (in_array($id, self::accountIds(), true)) {
+            return true;
+        }
+
+        $email = self::email();
+        if ($email === null) {
+            return false;
+        }
+
+        global $db;
+        $query = $db->prepare('SELECT 1 FROM bank_account WHERE id_account = :id AND user_email = :email');
+        $query->execute(['id' => $id, 'email' => $email]);
+        return (bool) $query->fetch();
+    }
+
+    private static function writeCookie(string $jwt, int $expires): void
+    {
+        setcookie(self::COOKIE_NAME, $jwt, self::cookieOptions($expires));
+        // Make the token readable within the request that just issued it.
+        $_COOKIE[self::COOKIE_NAME] = $jwt;
+    }
+
+    private static function cookieOptions(int $expires): array
+    {
+        return [
+            'expires'  => $expires,
+            'path'     => '/',
+            'httponly' => true,
+            'secure'   => !empty($_SERVER['HTTPS']),
+            'samesite' => 'Lax',
+        ];
+    }
+}
+
+/**
+ * Resolve a safe post-login redirect target. Only local /app/ paths are
+ * accepted (prevents open redirects); login/logout are excluded to avoid loops.
+ */
+function login_redirect_target(): string
+{
+    $redirect = $_POST['redirect'] ?? $_GET['redirect'] ?? '';
+
+    if (is_string($redirect)
+        && str_starts_with($redirect, '/app/')
+        && !str_contains($redirect, '//')
+        && !str_contains($redirect, '\\')
+        && !str_starts_with($redirect, '/app/login')
+        && !str_starts_with($redirect, '/app/logout')
+    ) {
+        return $redirect;
+    }
+
+    return '/app/home';
+}
+
+function requireLogin(): void
+{
+    if (!Auth::isAuthenticated()) {
+        $target = $_SERVER['REQUEST_URI'] ?? '/app/home';
+        header('Location: /app/login?redirect=' . urlencode($target));
         exit();
     }
 }
 
-function requireLoginApi()
+function requireLoginApi(): void
 {
-    if (session_status() !== PHP_SESSION_ACTIVE) session_start();
-    if (!isset($_SESSION['email'])) {
+    if (!Auth::isAuthenticated()) {
         sendAPIResponse(401, 'Not logged in', []);
     }
 }

--- a/controler/helpers/lang.php
+++ b/controler/helpers/lang.php
@@ -1,8 +1,55 @@
 <?php
 
+require_once($_SERVER['DOCUMENT_ROOT'] . '/controler/helpers/auth.php');
+
+/**
+ * Current user's { username, lang } read from the database, cached per request.
+ * Returns null when the request is not authenticated.
+ *
+ * @return array{username: string, lang: string}|null
+ */
+function current_user_record(): ?array
+{
+    static $record = null;
+    static $loaded = false;
+    if ($loaded) {
+        return $record;
+    }
+    $loaded = true;
+
+    $email = Auth::email();
+    if ($email === null) {
+        return $record = null;
+    }
+
+    global $db;
+    $query = $db->prepare('SELECT username, lang FROM user WHERE email = :email');
+    $query->execute(['email' => $email]);
+    return $record = ($query->fetch(PDO::FETCH_ASSOC) ?: null);
+}
+
+function current_username(): string
+{
+    return current_user_record()['username'] ?? '';
+}
+
 function get_locale(): string
 {
-    return $_SESSION['lang'] ?? 'English';
+    $record = current_user_record();
+    if ($record !== null && !empty($record['lang'])) {
+        return $record['lang'];
+    }
+
+    // Anonymous request: honour a language cookie if it names an available language.
+    $cookieLang = $_COOKIE['lang'] ?? null;
+    if ($cookieLang !== null) {
+        $codes = array_map(fn($l) => $l['code'], get_available_languages());
+        if (in_array($cookieLang, $codes, true)) {
+            return $cookieLang;
+        }
+    }
+
+    return 'English';
 }
 
 function trans(string $key): string

--- a/controler/login/login.php
+++ b/controler/login/login.php
@@ -1,19 +1,16 @@
 <?php
 
 require_once($_SERVER['DOCUMENT_ROOT'] . '/database/tables/user.php');
+require_once($_SERVER['DOCUMENT_ROOT'] . '/controler/helpers/auth.php');
 
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 $title = "Login";
-if (isset($_GET['input_email']) && isset($_GET['input_password'])) {
-    $email = $_GET['input_email'];
-    $password = $_GET['input_password'];
+if (isset($_POST['input_email']) && isset($_POST['input_password'])) {
+    $email = $_POST['input_email'];
+    $password = $_POST['input_password'];
 
     if (User::checkLogin($email, $password)) {
-        $user = new User($email);
-        $_SESSION['email'] = $email;
-        $_SESSION['username'] = $user->getUsername();
-        $_SESSION['lang'] = $user->getLang();
-        header("Location: " . ($_SESSION['redirect'] ?? '/app/home'));
+        Auth::issueForUser($email);
+        header("Location: " . login_redirect_target());
         exit();
     } else {
         $error = 1;

--- a/controler/login/logout.php
+++ b/controler/login/logout.php
@@ -1,6 +1,7 @@
 <?php
 
-if (session_status() !== PHP_SESSION_ACTIVE) session_start();
-if (session_destroy()) {
-    header("Location: /app/login");
-}
+require_once($_SERVER['DOCUMENT_ROOT'] . '/controler/helpers/auth.php');
+
+Auth::clear();
+header("Location: /app/login");
+exit();

--- a/controler/pages/operations.php
+++ b/controler/pages/operations.php
@@ -6,7 +6,7 @@ require_once $_SERVER['DOCUMENT_ROOT'] . '/database/tables/operation_type.php';
 
 requireLogin();
 
-$accounts = Account::getAccountsByUser($_SESSION['email']);
+$accounts = Account::getAccountsByUser(Auth::email());
 $operation_types = OperationType::getAll();
 
 $title = trans('operations.title');

--- a/controler/pages/settings.php
+++ b/controler/pages/settings.php
@@ -8,8 +8,8 @@ requireLogin();
 $title = trans('settings.title');
 $page_name = trans('settings.nav');
 
-$username = $_SESSION['username'] ?? '';
-$email = $_SESSION['email'] ?? '';
+$username = current_username();
+$email = Auth::email() ?? '';
 $mail_contact = getenv('MAIL_CONTACT') ?: '';
 
 $languages = get_available_languages();

--- a/database/api/v1/accounts/balance.php
+++ b/database/api/v1/accounts/balance.php
@@ -11,6 +11,10 @@ $date = $_GET['date'] ?? date('Y-m-d');
 
 checkRequiredArg(['id_account' => $id], ['id_account']);
 
+if (!Auth::ownsAccount((int) $id)) {
+    sendAPIResponse(403, 'Forbidden', []);
+}
+
 $balance = Operation::getLastOperationSoldByAccount($id, $date);
 
 sendAPIResponse(200, 'OK', ['balance' => $balance]);

--- a/database/api/v1/accounts/crud.php
+++ b/database/api/v1/accounts/crud.php
@@ -15,8 +15,12 @@ if ($method === 'GET') {
 
     if ($id != null) {
 
+        if (!Auth::ownsAccount((int) $id)) {
+            sendAPIResponse(403, 'Forbidden', []);
+        }
+
         $query = $db->prepare('SELECT id_account, label, type FROM bank_account WHERE id_account = :id AND user_email = :email');
-        $query->execute(['id' => $id, 'email' => $_SESSION['email']]);
+        $query->execute(['id' => $id, 'email' => Auth::email()]);
         $result = $query->fetch(PDO::FETCH_ASSOC);
 
         if (!$result) {
@@ -27,7 +31,7 @@ if ($method === 'GET') {
         sendAPIResponse(200, 'OK', $result);
     } else {
 
-        $result = Account::getAccountsByUser($_SESSION['email']);
+        $result = Account::getAccountsByUser(Auth::email());
 
         foreach ($result as $key => $value) {
             $result[$key]['sold'] = Operation::getLastOperationSoldByAccount($value['id_account'], date('Y-m-d'));
@@ -42,11 +46,14 @@ if ($method === 'POST') {
     ['label' => $label, 'type' => $type] = checkRequiredArg($body, ['label', 'type']);
     $sold = $body['sold'] ?: 0;
 
-    $id_account = Account::createAccount($label, $type, $_SESSION['email']);
+    $id_account = Account::createAccount($label, $type, Auth::email());
 
     if ($sold != 0) {
         Operation::createOperation("Init " . $label . " sold", "1999-01-01", $sold, 6, 0, $id_account);
     }
+
+    // The owned-accounts list changed: re-issue the token so its `acc` claim stays fresh.
+    Auth::refresh();
 
     sendAPIResponse(201, 'Account created', []);
 }
@@ -55,6 +62,10 @@ if ($method === 'POST') {
 if ($method === 'PATCH') {
 
     ['id' => $id, 'label' => $label, 'type' => $type, 'sold' => $sold] = checkRequiredArg($body, ['id', 'label', 'type', 'sold']);
+
+    if (!Auth::ownsAccount((int) $id)) {
+        sendAPIResponse(403, 'Forbidden', []);
+    }
 
     $account = new Account($id);
     $account->setLabel($label);
@@ -75,7 +86,15 @@ if ($method === 'PATCH') {
 if ($method === 'DELETE') {
     ['id' => $id] = checkRequiredArg($body, ['id']);
 
+    if (!Auth::ownsAccount((int) $id)) {
+        sendAPIResponse(403, 'Forbidden', []);
+    }
+
     Account::deleteAccount($id);
+
+    // The owned-accounts list changed: re-issue the token so its `acc` claim stays fresh.
+    Auth::refresh();
+
     sendAPIResponse(200, 'Account deleted', []);
 }
 

--- a/database/api/v1/accounts/operations.php
+++ b/database/api/v1/accounts/operations.php
@@ -15,6 +15,10 @@ $end = $_GET['end'] ?? null;
 
 checkRequiredArg(['id_account' => $id_account, 'start' => $start, 'end' => $end], ['id_account', 'start', 'end']);
 
+if (!Auth::ownsAccount((int) $id_account)) {
+    sendAPIResponse(403, 'Forbidden', []);
+}
+
 // GET /api/v1/accounts/operations?id_account=...&start=...&end=...
 $query = $db->prepare(
     'SELECT id_operation, label, date, amount, new_sold, category

--- a/database/api/v1/contact/contact.php
+++ b/database/api/v1/contact/contact.php
@@ -29,7 +29,7 @@ if (mb_strlen($message) > 10000) {
     sendAPIResponse(422, 'Message too long', []);
 }
 
-$userEmail = $_SESSION['email'];
+$userEmail = Auth::email();
 $user = new User($userEmail);
 
 // Coerce false (unset var) to '' so a missing config fails through the generic
@@ -57,7 +57,7 @@ try {
 }
 
 try {
-    // Acknowledge in the language the user picked (trans() reads $_SESSION['lang']).
+    // Acknowledge in the language the user picked (trans() reads the DB-backed locale).
     $confirmSubject = $headerSafe(trans('settings.contact_form.confirmation.subject'));
     $confirmHtml = buildConfirmationMailHtml($username, $theme, $subject, $message, $sentAt);
     $confirmText = buildConfirmationMailText($username, $theme, $subject, $message, $sentAt);

--- a/database/api/v1/events/crud.php
+++ b/database/api/v1/events/crud.php
@@ -12,14 +12,16 @@ if ($method === 'GET') {
 
     $date = sanitize_date($_GET['date'] ?? date('Y-m-d'));
     $futureDate = date('Y-m-d', strtotime('+1 year', strtotime($date)));
-    $accounts = json_decode($_GET['accounts'] ?? '[]');
     $limit = isset($_GET['limit']) ? ' LIMIT ' . (int)$_GET['limit'] : '';
 
+    // Keep only the accounts the caller actually owns (defence against IDOR).
+    $accounts = array_values(array_filter(
+        array_map('intval', (array) json_decode($_GET['accounts'] ?? '[]')),
+        fn($a) => Auth::ownsAccount($a)
+    ));
+
     if (empty($accounts)) {
-        sendAPIResponse(400, 'No account provided', []);
-    }
-    foreach ($accounts as $account) {
-        $account = sanitize_int($account ?? -1);
+        sendAPIResponse(200, 'OK', []);
     }
 
     $placeholders = implode(',', array_fill(0, count($accounts), '?'));
@@ -39,6 +41,10 @@ if ($method === 'GET') {
 if ($method === 'POST') {
     ['label' => $label, 'start' => $start, 'end' => $end, 'amount' => $amount, 'frequency' => $frequency, 'category' => $category, 'id_account' => $id_account] = checkRequiredArg($body, ['label', 'start', 'end', 'amount', 'frequency', 'category', 'id_account']);
 
+    if (!Auth::ownsAccount((int) $id_account)) {
+        sendAPIResponse(403, 'Forbidden', []);
+    }
+
     $start = sanitize_date($start ?? '');
     $end   = sanitize_date($end ?? '');
 
@@ -50,6 +56,8 @@ if ($method === 'POST') {
 // PATCH /api/v1/events
 if ($method === 'PATCH') {
     ['id' => $id, 'label' => $label, 'amount' => $amount, 'start' => $start, 'end' => $end, 'frequency' => $frequency, 'category' => $category] = checkRequiredArg($body, ['id', 'label', 'amount', 'start', 'end', 'frequency', 'category']);
+
+    requireEventOwnership($db, (int) $id);
 
     $start = sanitize_date($start ?? '');
     $end   = sanitize_date($end ?? '');
@@ -70,9 +78,26 @@ if ($method === 'PATCH') {
 if ($method === 'DELETE') {
     ['id' => $id] = checkRequiredArg($body, ['id']);
 
+    requireEventOwnership($db, (int) $id);
+
     RegularEvent::deleteRegularEvent($id);
 
     sendAPIResponse(200, 'Event deleted', []);
 }
 
 sendAPIResponse(405, 'Method not allowed', []);
+
+/** Ensure the current user owns the account the event belongs to, or stop with 403/404. */
+function requireEventOwnership(PDO $db, int $eventId): void
+{
+    $query = $db->prepare('SELECT id_account FROM regular_event WHERE id_regular_event = :id');
+    $query->execute(['id' => $eventId]);
+    $event = $query->fetch(PDO::FETCH_ASSOC);
+
+    if (!$event) {
+        sendAPIResponse(404, 'Event not found', []);
+    }
+    if (!Auth::ownsAccount((int) $event['id_account'])) {
+        sendAPIResponse(403, 'Forbidden', []);
+    }
+}

--- a/database/api/v1/operations/crud.php
+++ b/database/api/v1/operations/crud.php
@@ -28,22 +28,28 @@ if ($method === 'GET') {
             sendAPIResponse(404, 'Operation not found', []);
         }
 
+        if (!Auth::ownsAccount((int) $result['id_account'])) {
+            sendAPIResponse(403, 'Forbidden', []);
+        }
+
         sendAPIResponse(200, 'OK', $result);
     }
 
     // GET /api/v1/operations?accounts=[...]&date=...&limit=...&label=...&category=...&regularity=...
-    $accounts = json_decode($_GET['accounts'] ?? '[]');
-    $date = sanitize_date($_GET['date'] ?? date('Y-m-d'));
-    $where = 'WHERE id_account IN (' . implode(',', array_fill(0, count($accounts), '?')) . ') AND date <= ?';
-    $params = array_merge($accounts, [$date]);
-    $limit = isset($_GET['limit']) ? ' LIMIT ' . (int)$_GET['limit'] : '';
+    // Keep only the accounts the caller actually owns (defence against IDOR).
+    $accounts = array_values(array_filter(
+        array_map('intval', (array) json_decode($_GET['accounts'] ?? '[]')),
+        fn($a) => Auth::ownsAccount($a)
+    ));
 
     if (empty($accounts)) {
         sendAPIResponse(200, 'OK', []);
     }
-    foreach ($accounts as $account) {
-        $account = sanitize_int($account ?? 0);
-    }
+
+    $date = sanitize_date($_GET['date'] ?? date('Y-m-d'));
+    $limit = isset($_GET['limit']) ? ' LIMIT ' . (int)$_GET['limit'] : '';
+    $where = 'WHERE id_account IN (' . implode(',', array_fill(0, count($accounts), '?')) . ') AND date <= ?';
+    $params = array_merge($accounts, [$date]);
 
     if (isset($_GET['regularity'])) {
         $regularity = sanitize_int($_GET['regularity']);
@@ -74,6 +80,10 @@ if ($method === 'GET') {
 if ($method === 'POST') {
     ['label' => $label, 'date' => $date, 'amount' => $amount, 'category' => $category, 'id_account' => $id_account] = checkRequiredArg($body, ['label', 'date', 'amount', 'category', 'id_account']);
 
+    if (!Auth::ownsAccount((int) $id_account)) {
+        sendAPIResponse(403, 'Forbidden', []);
+    }
+
     $date = sanitize_date($date ?? '');
     Operation::createOperation($label, $date, $amount, $category, 0, $id_account);
 
@@ -84,6 +94,17 @@ checkRequiredArg(['id' => $id], ['id']);
 
 // DELETE /api/v1/operations
 if ($method === 'DELETE') {
+    $query = $db->prepare('SELECT id_account FROM operation WHERE id_operation = :id');
+    $query->execute(['id' => $id]);
+    $op = $query->fetch(PDO::FETCH_ASSOC);
+
+    if (!$op) {
+        sendAPIResponse(404, 'Operation not found', []);
+    }
+    if (!Auth::ownsAccount((int) $op['id_account'])) {
+        sendAPIResponse(403, 'Forbidden', []);
+    }
+
     Operation::deleteOperation($id);
 
     sendAPIResponse(200, 'Operation deleted', []);

--- a/database/api/v1/operations/transaction.php
+++ b/database/api/v1/operations/transaction.php
@@ -17,6 +17,10 @@ if ($amount == 0 || $from_id == $to_id) {
     sendAPIResponse(201, 'No transaction created', []);
 }
 
+if (!Auth::ownsAccount((int) $from_id) || !Auth::ownsAccount((int) $to_id)) {
+    sendAPIResponse(403, 'Forbidden', []);
+}
+
 $from = new Account($from_id);
 $to = new Account($to_id);
 

--- a/database/api/v1/settings/crud.php
+++ b/database/api/v1/settings/crud.php
@@ -14,17 +14,16 @@ if ($username === false) {
     sendAPIResponse(400, 'Invalid or missing username', []);
 }
 
-$user = new User($_SESSION['email']);
+$user = new User(Auth::email());
 $user->setUsername($username);
 
 if (isset($body['lang'])) {
     $lang = sanitize_string($body['lang'], 50);
     $user->setLang($lang);
-    $_SESSION['lang'] = $user->getLang();
 }
 
 $user->update();
 
-$_SESSION['username'] = $username;
-
+// username and language are read from the database per request, so there is
+// nothing session-side to keep in sync here.
 sendAPIResponse(200, 'Settings updated', []);

--- a/public/view/helpers/header.php
+++ b/public/view/helpers/header.php
@@ -31,7 +31,7 @@ require_once $_SERVER['DOCUMENT_ROOT'] . '/controler/helpers/lang.php'; ?>
 
 			<div id="account">
 				<a id="username">
-					<?= htmlspecialchars($_SESSION['username'] ?? '') ?>
+					<?= htmlspecialchars(current_username()) ?>
 				</a>
 				<a href="/app/logout">
 					<img id="exit_icon" src="/assets/images/exit.png" alt="exit" width="50" height="50" loading="lazy">

--- a/public/view/login.php
+++ b/public/view/login.php
@@ -4,8 +4,9 @@
 <section id="section-core">
     <div class="form-box">
         <div class="form-value">
-            <form action="/app/login" method="get">
+            <form action="/app/login" method="post">
                 <h2>Login</h2>
+                <input type="hidden" name="redirect" value="<?= htmlspecialchars($_GET['redirect'] ?? '', ENT_QUOTES) ?>">
                 <div class="input-box">
                     <ion-icon name="mail-outline"></ion-icon>
                     <input id="email_id" type="email" name="input_email" required placeholder=" ">


### PR DESCRIPTION
# Refacto authentification → JWT sécurisé

## Context

L'authentification actuelle repose sur les **sessions PHP** (`$_SESSION['email' | 'username' | 'lang']`) :
- `requireLogin()` / `requireLoginApi()` vérifient `$_SESSION['email']` ([controler/helpers/auth.php](controler/helpers/auth.php)).
- Le login envoie **email + mot de passe en query string GET** ([public/view/login.php:7](public/view/login.php), lus dans [controler/login/login.php:8](controler/login/login.php)) → fuite des identifiants dans l'URL, l'historique et les logs serveur.
- Les endpoints `accounts` PATCH/DELETE ne vérifient **pas** que le compte appartient au demandeur ([database/api/v1/accounts/crud.php:55-79](database/api/v1/accounts/crud.php)) → IDOR.
- La table `user` n'a **pas d'identifiant numérique** (PK = `email`).

Objectif : remplacer les sessions par un **JWT signé** stocké dans un **cookie httpOnly**, contenant l'utilisateur **par ID** (pas par mail), son **niveau de permission** (`account_level` 0/1) et la **liste des IDs de comptes** qu'il possède. Suivre les bonnes pratiques (lib éprouvée, secret hors code, cookie durci, POST pour les creds, correction des IDOR) et rester compatible avec la branche `FEAT-CreateAccount` (register via `pending_account`).

## Décisions actées
- **Lib** : `firebase/php-jwt` (Composer), HS256.
- **ID** : `ALTER TABLE user ADD id_user INT AUTO_INCREMENT UNIQUE` — **email reste la PK**, `bank_account.user_email` inchangé (migration non-cassante).
- **Contenu token (minimal)** : `sub`=id_user, `email`, `lvl`=account_level, `acc`=[id_account…], `iat`, `exp`. `username` et `lang` **ne sont pas** dans le token → lus en DB par requête (toujours frais).

## Payload JWT
```
{ "sub": <id_user:int>, "email": "<email>", "lvl": <0|1>,
  "acc": [<id_account>,…], "iat": <ts>, "exp": <ts> }
```
Le claim `acc` est ré-émis (cookie réécrit) à chaque création/suppression de compte pour rester frais.

## Modifications

### 1. Dépendance & secret
- `composer require firebase/php-jwt` (met à jour `composer.json` / `composer.lock` / `vendor/`).
- `.env` : ajouter `JWT_SECRET=<64 hex aléatoires>`. `.env-example` : ajouter `JWT_SECRET=change-me-64-hex`.
- `connexion.php` charge déjà le `.env` via `getenv()` — réutiliser `getenv('JWT_SECRET')`.

### 2. Migration BDD — `database/migrations/add_id_user_to_user.sql` (nouveau)
```sql
ALTER TABLE `user`
  ADD COLUMN `id_user` INT NOT NULL AUTO_INCREMENT UNIQUE FIRST;
```
(À exécuter une fois, comme les migrations existantes.)

### 3. Helper d'auth central — refonte de [controler/helpers/auth.php](controler/helpers/auth.php)
Classe `Auth` (statique) encapsulant firebase/php-jwt + le cookie :
- `Auth::issueForUser(string $email)` : requête légère `id_user, account_level` + `SELECT id_account FROM bank_account WHERE user_email=:email` → construit les claims → `JWT::encode` → `setcookie`.
- `Auth::refresh()` : réémet le cookie pour l'utilisateur courant (après create/delete de compte).
- `Auth::verify()` : lit le cookie, `JWT::decode(new Key($secret,'HS256'))` dans un `try/catch` (expiré/invalide → `null`), résultat mis en cache statique.
- `Auth::clear()` : cookie expiré (logout).
- Accès aux claims : `Auth::userId()`, `Auth::email()`, `Auth::level()`, `Auth::accountIds()`.
- `Auth::ownsAccount(int $id)` : vérifie l'appartenance (`acc` du token, avec repli DB `SELECT 1 … WHERE id_account=? AND user_email=?`) — anti-IDOR.
- **Conserver les fonctions `requireLogin()` / `requireLoginApi()`** (mêmes noms, déjà appelées partout) : `requireLogin()` → si `!verify()` redirige vers `/app/login?redirect=<urlencodé>` ; `requireLoginApi()` → `sendAPIResponse(401,…)`.

Cookie : `setcookie('auth_token', $jwt, ['expires'=>exp, 'path'=>'/', 'httponly'=>true, 'secure'=>!empty($_SERVER['HTTPS']), 'samesite'=>'Lax'])`. `secure` conditionné à HTTPS pour rester utilisable en local WAMP. `SameSite=Lax` = protection CSRF principale (l'API est same-origin, JSON → préflight).

**Gotcha** `User::__destruct()` appelle `exit` ([database/tables/user.php:33](database/tables/user.php)) : pour lire username/lang par requête, **ne pas instancier `User`** dans le helper — faire une requête directe (`SELECT username, lang FROM user WHERE email=?`) mise en cache statique.

### 4. username / lang par requête — [controler/helpers/lang.php](controler/helpers/lang.php)
- Ajouter un helper (ex. `current_username()` et une source lang) qui lit `username, lang` en DB pour `Auth::email()` (caché), et renvoie `''` / défaut si non authentifié.
- `get_locale()` : si authentifié → `lang` DB de l'utilisateur ; sinon → `$_COOKIE['lang']` validé (contre la liste des langues dispo) ou `'English'`. Supprime la dépendance à `$_SESSION['lang']` (les pages anonymes login/register poseront un simple cookie `lang` non-httpOnly lors du choix de langue).

### 5. Login / Logout
- [public/view/login.php:7](public/view/login.php) : `method="get"` → `method="post"`.
- [controler/login/login.php](controler/login/login.php) : lire `$_POST['input_email' | 'input_password']` ; sur `User::checkLogin` OK → `Auth::issueForUser($email)` (plus de `$_SESSION`) → rediriger vers `redirect_target()` (valide `$_GET['redirect']` : doit commencer par `/app/` et ne pas contenir `//`/`\`, sinon `/app/home`).
- [controler/login/logout.php](controler/login/logout.php) : `Auth::clear()` puis redirection `/app/login` (supprimer `session_destroy`).

### 6. Remplacer tous les usages `$_SESSION` (grep : 15 occurrences)
- `$_SESSION['email']` → `Auth::email()` : [accounts/crud.php:19,30,45](database/api/v1/accounts/crud.php), [settings/crud.php:17](database/api/v1/settings/crud.php), [contact/contact.php:32](database/api/v1/contact/contact.php), [pages/operations.php:9](controler/pages/operations.php), [pages/settings.php:12](controler/pages/settings.php).
- `$_SESSION['username']` → `current_username()` : [header.php:34](public/view/helpers/header.php), [pages/settings.php:11](controler/pages/settings.php).
- `settings/crud.php` : supprimer les écritures `$_SESSION['lang']`/`$_SESSION['username']` (maintenant en DB via `User::update()` déjà appelé) ; garder `new User(Auth::email())`.
- `contact/contact.php` : `$userEmail = Auth::email()` (le reste inchangé, `new User` y reste licite).

### 7. Token frais + anti-IDOR — [database/api/v1/accounts/crud.php](database/api/v1/accounts/crud.php)
- POST (create) et DELETE : après la mutation, `Auth::refresh()` (le claim `acc` change).
- GET-by-id / PATCH / DELETE : `if (!Auth::ownsAccount($id)) sendAPIResponse(403,…)` **avant** toute opération (corrige l'IDOR PATCH/DELETE actuel).
- **Audit** des autres endpoints acceptant un `id_account` en entrée ([operations/crud.php](database/api/v1/operations/crud.php), [operations/transaction.php](database/api/v1/operations/transaction.php), [accounts/operations.php](database/api/v1/accounts/operations.php), [accounts/balance.php](database/api/v1/accounts/balance.php), [events/crud.php](database/api/v1/events/crud.php)) → y ajouter le même garde `Auth::ownsAccount()`.

### 8. Compatibilité `FEAT-CreateAccount` (à venir)
- Le gateway de cette branche introduit des **routes publiques** + `requireLoginApi()` pour le reste ([api_gateway.php](database/api/v1/api_gateway.php)) : le nouveau `requireLoginApi()` (JWT) reste compatible, aucune signature changée.
- `validation.php` de cette branche pose `$_SESSION['email' | 'username' | 'lang']` après register : au merge, remplacer ces 3 lignes par **`Auth::issueForUser($email);`**. `Auth::issueForUser` est conçu pour ça (login **et** register l'utilisent). À documenter dans le message de commit / PR.
- `create_account.php` / `lang/set.php` posent la langue anonyme : cohérent avec le cookie `lang` non-httpOnly de l'étape 4.

## Vérification (end-to-end, via WAMP)
1. `composer install` OK, `vendor/firebase` présent ; exécuter la migration sur la base locale ; vérifier `id_user` peuplé (`SELECT email,id_user FROM user`).
2. **Login** : soumettre le formulaire → requête en **POST** (creds hors URL) ; cookie `auth_token` httpOnly présent (DevTools → Application → Cookies) ; décoder le payload sur jwt.io → `sub`,`email`,`lvl`,`acc` corrects.
3. **Accès protégé** : sans cookie, `/app/home` redirige vers `/app/login?redirect=/app/home` ; un appel API sans cookie → `401`.
4. **Redirect** : viser `/app/operations` déconnecté → après login on atterrit bien sur `/app/operations`.
5. **Header/settings** : username et langue s'affichent (lus en DB) ; changer la langue dans settings → persistée et reflétée au rechargement.
6. **Token frais** : créer un compte → le cookie est réécrit, `acc` contient le nouvel `id_account`.
7. **Anti-IDOR** : tenter `DELETE /api/v1/accounts` avec un `id` d'un autre utilisateur → `403`.
8. **Logout** : cookie `auth_token` supprimé ; `/app/home` re-redirige vers login.
9. Régression : parcourir home / accounts / operations / analytics / budget / events / contact sans erreur PHP (activer `display_errors` ou vérifier les logs WAMP).

_Il y a une modification au niveau de la base de données, voir ci dessus_

_Ps : oui je l'ai fais rédiger par claude pour pas perdre de temps à la fin_